### PR TITLE
Run `cargo fmt`

### DIFF
--- a/src/config.rs
+++ b/src/config.rs
@@ -1,8 +1,8 @@
-use chrono::{DateTime, Utc,Duration};
 use chrono::serde::ts_seconds_option as to_tsopt;
-use serde::{Serialize, Deserialize};
-use serde_with::{serde_as,DurationSeconds};
+use chrono::{DateTime, Duration, Utc};
 use confy;
+use serde::{Deserialize, Serialize};
+use serde_with::{serde_as, DurationSeconds};
 use std::fs;
 
 #[serde_as]
@@ -23,11 +23,12 @@ pub struct TimerInfo {
 }
 
 impl std::default::Default for TimerInfo {
-    fn default() -> Self { Self {
+    fn default() -> Self {
+        Self {
             start_work: Some(Utc::now()),
             start_rest: Some(Utc::now() + chrono::Duration::minutes(25)),
             work_duration: Duration::minutes(25), // Default to 25 minutes
-            rest_duration: Duration::minutes(5), // Default to 5 minutes
+            rest_duration: Duration::minutes(5),  // Default to 5 minutes
             pause_time: Some(Utc::now()),
             run_state: false,
         }
@@ -44,25 +45,23 @@ pub fn save_timer(timer_info: &TimerInfo) -> Result<(), confy::ConfyError> {
 
 pub fn save_cstm(work: i64, rest: i64) -> Result<(), confy::ConfyError> {
     let timer_info = TimerInfo {
-            start_work: Some(Utc::now()),
-            start_rest: Some(Utc::now() + chrono::Duration::minutes(work)),
-            work_duration: Duration::minutes(work),
-            rest_duration: Duration::minutes(rest),
-            pause_time: Some(Utc::now()),
-            run_state: false,
-
+        start_work: Some(Utc::now()),
+        start_rest: Some(Utc::now() + chrono::Duration::minutes(work)),
+        work_duration: Duration::minutes(work),
+        rest_duration: Duration::minutes(rest),
+        pause_time: Some(Utc::now()),
+        run_state: false,
     };
     save_timer(&timer_info)
 }
 
 pub fn reset_timer() {
-   // Define the path of the configuration file
-let config_path = confy::get_configuration_file_path("timer_state", None);
+    // Define the path of the configuration file
+    let config_path = confy::get_configuration_file_path("timer_state", None);
 
-// Delete the configuration file
-match fs::remove_file(&config_path.unwrap()) {
-    Ok(_) => println!("Configuration file deleted successfully."),
-    Err(err) => println!("Failed to delete configuration file: {}", err),
-}
-
+    // Delete the configuration file
+    match fs::remove_file(&config_path.unwrap()) {
+        Ok(_) => println!("Configuration file deleted successfully."),
+        Err(err) => println!("Failed to delete configuration file: {}", err),
+    }
 }

--- a/src/main.rs
+++ b/src/main.rs
@@ -1,23 +1,23 @@
-use chrono::{Utc, Duration};
-use flowst::{parse_args, Action};
+use chrono::{Duration, Utc};
 use crossterm::{
     event::{DisableMouseCapture, EnableMouseCapture},
     execute,
     terminal::{disable_raw_mode, enable_raw_mode, EnterAlternateScreen, LeaveAlternateScreen},
 };
-use tui::{Terminal,backend::CrosstermBackend};
+use flowst::{parse_args, Action};
 use std::{error::Error, io};
+use tui::{backend::CrosstermBackend, Terminal};
 
 use flowst::timer;
 
-use flowst::config::{TimerInfo, load_timer, save_timer, reset_timer};
+use flowst::config::{load_timer, reset_timer, save_timer, TimerInfo};
 
-#[tokio::main(flavor="current_thread")]
+#[tokio::main(flavor = "current_thread")]
 async fn main() -> Result<(), Box<dyn Error>> {
     let args = parse_args();
 
     match &args.command {
-        Action::Start(arg)=> {
+        Action::Start(arg) => {
             let work = arg.work.into();
             let rest = arg.rest.into();
 
@@ -27,26 +27,24 @@ async fn main() -> Result<(), Box<dyn Error>> {
                 rest_duration: Duration::minutes(rest),
                 start_rest: Some(Utc::now() + Duration::minutes(work)),
                 pause_time: Some(Utc::now()),
-                run_state: true
+                run_state: true,
             };
-            
+
             save_timer(&timer_info)?;
 
             let (mut rec, _) = timer::start_timer().await;
             if let Some(message) = rec.recv().await {
                 println!("Timer started. {} until break", message);
             }
-            
 
             Ok(())
-        },
+        }
         Action::Toggle => {
             let mut timer_info = load_timer()?;
-            
+
             if timer_info.run_state {
                 println!("Timer paused.");
-            }   
-            else {
+            } else {
                 println!("Timer resumed.");
             }
 
@@ -54,13 +52,12 @@ async fn main() -> Result<(), Box<dyn Error>> {
             timer_info.run_state = !timer_info.run_state;
             save_timer(&timer_info)?;
 
-
             Ok(())
-        },
+        }
         Action::Reset => {
             reset_timer();
             Ok(())
-        },
+        }
         Action::App => {
             enable_raw_mode()?;
             let mut stdout = io::stdout();
@@ -69,8 +66,8 @@ async fn main() -> Result<(), Box<dyn Error>> {
             let mut terminal = Terminal::new(backend)?;
 
             let (rec, cancel) = timer::start_timer().await;
-       
-        flowst::run_app(&mut terminal, cancel, rec).await?;
+
+            flowst::run_app(&mut terminal, cancel, rec).await?;
 
             // restore terminal
             disable_raw_mode()?;
@@ -79,8 +76,7 @@ async fn main() -> Result<(), Box<dyn Error>> {
                 LeaveAlternateScreen,
                 DisableMouseCapture
             )?;
-           terminal.show_cursor()?;
-
+            terminal.show_cursor()?;
 
             Ok(())
         }

--- a/src/timer.rs
+++ b/src/timer.rs
@@ -1,9 +1,12 @@
-use tokio::sync::mpsc;
-use chrono::Duration;
 use crate::config::TimerInfo;
-use std::sync::{Arc,atomic::{AtomicBool,Ordering}};
-fn format_seconds(seconds: i64) -> Vec<i64>{
-       return vec![(seconds/60),(seconds%60)];   
+use chrono::Duration;
+use std::sync::{
+    atomic::{AtomicBool, Ordering},
+    Arc,
+};
+use tokio::sync::mpsc;
+fn format_seconds(seconds: i64) -> Vec<i64> {
+    return vec![(seconds / 60), (seconds % 60)];
 }
 
 pub fn print_time(seconds: i64) -> String {
@@ -11,14 +14,17 @@ pub fn print_time(seconds: i64) -> String {
     format!("{} minutes and {} seconds remaining ", minutes, seconds)
 }
 
-async fn countdown(seconds: Duration, cancel: Arc<AtomicBool>,  sender: tokio::sync::mpsc::Sender<String>) -> Result<(), std::io::Error>{
-
+async fn countdown(
+    seconds: Duration,
+    cancel: Arc<AtomicBool>,
+    sender: tokio::sync::mpsc::Sender<String>,
+) -> Result<(), std::io::Error> {
     for i in (0..=(seconds.num_seconds())).rev() {
         if cancel.load(Ordering::Relaxed) {
             break;
-        }  
+        }
 
-        let countdown_string = print_time(i);          
+        let countdown_string = print_time(i);
 
         if let Err(_) = sender.send(countdown_string).await {
             break;
@@ -29,62 +35,78 @@ async fn countdown(seconds: Duration, cancel: Arc<AtomicBool>,  sender: tokio::s
     Ok(())
 }
 
-pub async fn paused(timer_info: TimerInfo, cancel: Arc<AtomicBool>, sender: tokio::sync::mpsc::Sender<String>)-> Result<(),std::io::Error> {
-        let start_work_elapsed = chrono::Utc::now().signed_duration_since(timer_info.start_work.unwrap());
+pub async fn paused(
+    timer_info: TimerInfo,
+    cancel: Arc<AtomicBool>,
+    sender: tokio::sync::mpsc::Sender<String>,
+) -> Result<(), std::io::Error> {
+    let start_work_elapsed =
+        chrono::Utc::now().signed_duration_since(timer_info.start_work.unwrap());
 
-        let pause_elapsed = if start_work_elapsed.num_seconds() <= timer_info.work_duration.num_seconds() {
-            timer_info.work_duration - timer_info.pause_time.unwrap().signed_duration_since(timer_info.start_work.unwrap())
+    let pause_elapsed =
+        if start_work_elapsed.num_seconds() <= timer_info.work_duration.num_seconds() {
+            timer_info.work_duration
+                - timer_info
+                    .pause_time
+                    .unwrap()
+                    .signed_duration_since(timer_info.start_work.unwrap())
         } else {
-            timer_info.rest_duration - timer_info.pause_time.unwrap().signed_duration_since(timer_info.start_rest.unwrap())
+            timer_info.rest_duration
+                - timer_info
+                    .pause_time
+                    .unwrap()
+                    .signed_duration_since(timer_info.start_rest.unwrap())
         };
-        
-        while !timer_info.run_state {
-            if cancel.load(Ordering::Relaxed) {
-                break;
-             }  
-            let message = print_time(pause_elapsed.num_seconds());
-            if let Err(_) = sender.send(message).await {
-                break;
-            }
-            tokio::time::sleep(std::time::Duration::from_secs(1)).await;
-        }
-    Ok(())
 
+    while !timer_info.run_state {
+        if cancel.load(Ordering::Relaxed) {
+            break;
+        }
+        let message = print_time(pause_elapsed.num_seconds());
+        if let Err(_) = sender.send(message).await {
+            break;
+        }
+        tokio::time::sleep(std::time::Duration::from_secs(1)).await;
+    }
+    Ok(())
 }
 
-
 pub async fn start_timer() -> (tokio::sync::mpsc::Receiver<String>, Arc<AtomicBool>) {
-  let timer_info = crate::config::load_timer().unwrap();
-  let cancel = Arc::new(AtomicBool::new(false));
-  let cancel1 = cancel.clone();
-  let cancel2 = cancel.clone();
-  let cancel3 = cancel.clone();
+    let timer_info = crate::config::load_timer().unwrap();
+    let cancel = Arc::new(AtomicBool::new(false));
+    let cancel1 = cancel.clone();
+    let cancel2 = cancel.clone();
+    let cancel3 = cancel.clone();
 
-  let start_work_elapsed = chrono::Utc::now().signed_duration_since(timer_info.start_work.unwrap());
-  let start_rest_elapsed = chrono::Utc::now().signed_duration_since(timer_info.start_rest.unwrap());
+    let start_work_elapsed =
+        chrono::Utc::now().signed_duration_since(timer_info.start_work.unwrap());
+    let start_rest_elapsed =
+        chrono::Utc::now().signed_duration_since(timer_info.start_rest.unwrap());
 
-  let work = if start_work_elapsed.num_seconds() <=0 {timer_info.work_duration} else {timer_info.work_duration - start_work_elapsed};
-  let rest = if start_rest_elapsed.num_seconds() <=0 {timer_info.rest_duration} else {timer_info.rest_duration - start_rest_elapsed};
-        
-  let (sender, receiver) = mpsc::channel(1);
-  let state = timer_info.run_state;
+    let work = if start_work_elapsed.num_seconds() <= 0 {
+        timer_info.work_duration
+    } else {
+        timer_info.work_duration - start_work_elapsed
+    };
+    let rest = if start_rest_elapsed.num_seconds() <= 0 {
+        timer_info.rest_duration
+    } else {
+        timer_info.rest_duration - start_rest_elapsed
+    };
 
+    let (sender, receiver) = mpsc::channel(1);
+    let state = timer_info.run_state;
 
-  if state {
+    if state {
         tokio::spawn(async move {
             let _ = countdown(work, cancel1, sender.clone()).await;
             let _ = countdown(rest, cancel2, sender).await;
         });
-    }
-    else {
+    } else {
         tokio::spawn(async move {
-            let _ = paused(timer_info,cancel3, sender.clone()).await;
+            let _ = paused(timer_info, cancel3, sender.clone()).await;
         });
     }
 
     (receiver, cancel)
 }
-
-
-    
-

--- a/src/ui.rs
+++ b/src/ui.rs
@@ -4,13 +4,13 @@ use tui::{
     backend::Backend,
     layout::{Alignment, Constraint, Direction, Layout},
     style::{Color, Modifier, Style},
-    text::{Span,Spans,Text},
-    widgets::{Block, BorderType, Borders,Paragraph,List,ListItem,ListState,Wrap},
+    text::{Span, Spans, Text},
+    widgets::{Block, BorderType, Borders, List, ListItem, ListState, Paragraph, Wrap},
     Frame, Terminal,
 };
 
-pub fn chunks<B: Backend>(f: &mut Frame<B>) -> Vec<Rect>{
-let chunks = Layout::default()
+pub fn chunks<B: Backend>(f: &mut Frame<B>) -> Vec<Rect> {
+    let chunks = Layout::default()
         .direction(Direction::Vertical)
         .margin(1)
         .constraints(
@@ -18,132 +18,119 @@ let chunks = Layout::default()
                 Constraint::Percentage(20),
                 Constraint::Percentage(70),
                 Constraint::Percentage(10),
-            ].as_ref()
+            ]
+            .as_ref(),
         )
         .split(f.size());
 
-let lower_chunks = Layout::default()
-    .direction(Direction::Horizontal)
-    .margin(1)
-    .constraints(
-        [
-        Constraint::Percentage(20),
-        Constraint::Percentage(80),
-        ].as_ref()
-    )
-    .split(chunks[1]);
+    let lower_chunks = Layout::default()
+        .direction(Direction::Horizontal)
+        .margin(1)
+        .constraints([Constraint::Percentage(20), Constraint::Percentage(80)].as_ref())
+        .split(chunks[1]);
 
-vec![chunks[0],lower_chunks[0], lower_chunks[1], chunks[2]]
+    vec![chunks[0], lower_chunks[0], lower_chunks[1], chunks[2]]
 }
 
 pub fn tim_display<B: Backend>(f: &mut Frame<B>, tim_msg: &str) {
     let chunks = chunks(f);
-    let block = Block::default()
-         .title("Timer")
-         .borders(Borders::ALL);
+    let block = Block::default().title("Timer").borders(Borders::ALL);
     f.render_widget(block, chunks[0]);
 
     let inner_area = Layout::default()
         .direction(Direction::Vertical)
         .constraints([Constraint::Percentage(100)].as_ref())
-        .margin(1)  
+        .margin(1)
         .split(chunks[0])[0];
 
     let style = Style::default()
         .fg(Color::Yellow)
         .add_modifier(Modifier::ITALIC);
 
-    let text = vec![
-        tui::text::Spans::from(Span::styled(tim_msg,style)),
-    ]; 
-    let paragraph = Paragraph::new(text).wrap(Wrap { trim:  true });
+    let text = vec![tui::text::Spans::from(Span::styled(tim_msg, style))];
+    let paragraph = Paragraph::new(text).wrap(Wrap { trim: true });
     f.render_widget(paragraph, inner_area);
 }
 
 pub fn config_display<B: Backend>(f: &mut Frame<B>, selected: &mut tui::widgets::ListState) {
     let chunks = chunks(f);
 
-  //Config block
-    let block = Block::default()
-         .title("Configs")
-         .borders(Borders::ALL);
+    //Config block
+    let block = Block::default().title("Configs").borders(Borders::ALL);
     f.render_widget(block, chunks[1]);
 
     let inner_area = Layout::default()
         .direction(Direction::Vertical)
-        .constraints([
-                     Constraint::Percentage(10),
-                     Constraint::Percentage(90),
-        ].as_ref())
+        .constraints([Constraint::Percentage(10), Constraint::Percentage(90)].as_ref())
         .margin(1)
         .split(chunks[1])[1];
-    
-    let items = [ListItem::new("25 : 5"),ListItem::new("50 : 10"),ListItem::new("60 : 15")];
-      let conflist = List::new(items)
+
+    let items = [
+        ListItem::new("25 : 5"),
+        ListItem::new("50 : 10"),
+        ListItem::new("60 : 15"),
+    ];
+    let conflist = List::new(items)
         .block(Block::default().title("Timers").borders(Borders::ALL))
         .style(Style::default().fg(Color::White))
         .highlight_style(
             Style::default()
-            .add_modifier(Modifier::ITALIC)
-            .add_modifier(Modifier::BOLD)
-            .fg(Color::Blue)
-            )
+                .add_modifier(Modifier::ITALIC)
+                .add_modifier(Modifier::BOLD)
+                .fg(Color::Blue),
+        )
         .highlight_symbol(">>");
 
-    f.render_stateful_widget(conflist,inner_area, selected);
-
+    f.render_stateful_widget(conflist, inner_area, selected);
 }
 
 pub fn ui<B: Backend>(f: &mut Frame<B>) {
-   let chunks = chunks(f); 
-    
-  
+    let chunks = chunks(f);
+
     //Welcome block
 
-    let block = Block::default()
-         .title("Welcome!")
-         .borders(Borders::ALL);
+    let block = Block::default().title("Welcome!").borders(Borders::ALL);
     f.render_widget(block, chunks[2]);
 
     let inner_area = Layout::default()
         .direction(Direction::Vertical)
         .constraints([Constraint::Percentage(100)].as_ref())
-        .margin(1)  
+        .margin(1)
         .split(chunks[2])[0];
 
     let style = Style::default()
         .fg(Color::Cyan)
         .add_modifier(Modifier::BOLD);
 
-     let logo = Text::styled(r#" 
+    let logo = Text::styled(
+        r#" 
    __ _                   _   
   / _| |                 | |  
  | |_| | _____      _____| |_ 
  |  _| |/ _ \ \ /\ / / __| __|
  | | | | (_) \ V  V /\__ \ |_ 
  |_| |_|\___/ \_/\_/ |___/\__|                                                     
-"#, style);
-     let paragraph = Paragraph::new(logo).wrap(Wrap{ trim: false});
-    
+"#,
+        style,
+    );
+    let paragraph = Paragraph::new(logo).wrap(Wrap { trim: false });
+
     f.render_widget(paragraph, inner_area);
 
     //Controls block
-    let block = Block::default()
-         .title("Controls")
-         .borders(Borders::ALL);
+    let block = Block::default().title("Controls").borders(Borders::ALL);
     f.render_widget(block, chunks[3]);
 
     let inner_area = Layout::default()
         .direction(Direction::Vertical)
         .constraints([Constraint::Percentage(100)].as_ref())
-        .margin(1)  
+        .margin(1)
         .split(chunks[3])[0];
 
-    let text = vec![
-        Spans::from(Span::styled("q - quit | p - pause/resume",style)),
-    ]; 
-    let paragraph = Paragraph::new(text).wrap(Wrap { trim:  true });
+    let text = vec![Spans::from(Span::styled(
+        "q - quit | p - pause/resume",
+        style,
+    ))];
+    let paragraph = Paragraph::new(text).wrap(Wrap { trim: true });
     f.render_widget(paragraph, inner_area);
-
 }
-


### PR DESCRIPTION
Rust has a built-in command called `cargo fmt` that reformats your code. I really like using it because then I don't need to worry about formatting it at all. My editor is set up to format whenever I save a file.

But I know some people don't like auto-formatters, so feel free to close this if you'd rather not use `cargo fmt`.