### PR TITLE
Fixed Windows bug

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -122,6 +122,11 @@ pub async fn run_app<B: Backend>(
         let mut selected = 0;
         loop {
             if let Event::Key(key) = event::read().unwrap() {
+                //only registers key presses (i.e. not key releases and repeats)
+                //only affects Windows
+                if key.kind != event::KeyEventKind::Press {
+                    continue;
+                }
                 match key.code {
                     KeyCode::Char('q') => {
                         tx.send(Message::Quit).unwrap();


### PR DESCRIPTION
I think I fixed your Windows bug.
The problem was that Windows generates both a "press" key event and a "release" key event, so the timer state would toggle twice, making it seem like it wasn't toggling at all. 